### PR TITLE
Do not create destination just by running the app

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -18,6 +18,7 @@
 public class Application : Gtk.Application {
     private MainWindow window;
     public static Settings settings;
+    public bool is_first_run { get; private set; }
 
     public Application () {
         Object (
@@ -41,6 +42,11 @@ public class Application : Gtk.Application {
 
         var window_x = settings.get_int ("window-x");
         var window_y = settings.get_int ("window-y");
+
+        if (Application.settings.get_string ("destination") == "") {
+            is_first_run = true;
+            Application.settings.set_boolean ("auto-save", false);
+        }
 
         window = new MainWindow (this);
 

--- a/src/Views/RecordView.vala
+++ b/src/Views/RecordView.vala
@@ -140,7 +140,7 @@ public class RecordView : Gtk.Box {
 
                 string destination = Application.settings.get_string ("destination");
 
-                if (Application.settings.get_boolean ("auto-save")) { // The app saved files automatically
+                if (!window.app.is_first_run && Application.settings.get_boolean ("auto-save")) { // The app saved files automatically
                     try {
                         var uri = File.new_for_path (destination + "/" + filename + suffix);
                         tmp_source.move (uri, FileCopyFlags.OVERWRITE);
@@ -153,13 +153,14 @@ public class RecordView : Gtk.Box {
                         _("Save your recording"), window, Gtk.FileChooserAction.SAVE,
                         _("Save"), _("Cancel"));
                     filechooser.set_current_name (filename + suffix);
-                    filechooser.set_filename (destination);
+                    filechooser.set_filename (get_destionation ());
                     filechooser.do_overwrite_confirmation = true;
 
                     if (filechooser.run () == Gtk.ResponseType.ACCEPT) {
                         try {
                             var uri = File.new_for_path (filechooser.get_filename ());
                             tmp_source.move (uri, FileCopyFlags.OVERWRITE);
+                            Application.settings.set_string ("destination", filechooser.get_current_folder ());
                             window.welcome_view.show_success_button ();
                         } catch (Error e) {
                             stderr.printf ("Error: %s\n", e.message);
@@ -183,6 +184,16 @@ public class RecordView : Gtk.Box {
         }
 
         return true;
+    }
+
+    private string get_destionation () {
+        string destination = Application.settings.get_string ("destination");
+
+        if (destination == "") {
+            destination = Environment.get_home_dir ();
+        }
+
+        return destination;
     }
 
     public void start_recording () {

--- a/src/Views/WelcomeView.vala
+++ b/src/Views/WelcomeView.vala
@@ -64,6 +64,11 @@ public class WelcomeView : Gtk.Box {
         var auto_save = new Gtk.Switch ();
         auto_save.halign = Gtk.Align.START;
         auto_save.active = Application.settings.get_boolean ("auto-save");
+        if (window.app.is_first_run) {
+            auto_save_label.sensitive = false;
+            auto_save.sensitive = false;
+            auto_save.tooltip_text = _("This option will be available once you save your recording and restart the app");
+        }
 
         var destination_chooser = new Gtk.FileChooserButton (
             _("Choose a default destination"),
@@ -132,12 +137,6 @@ public class WelcomeView : Gtk.Box {
 
     private string get_destination () {
         string destination = Application.settings.get_string ("destination");
-
-        if (destination == "") {
-            /// TRANSLATORS: The name of the folder which recordings are saved
-            destination = Environment.get_home_dir () + "/%s".printf (_("Recordings"));
-            Application.settings.set_string ("destination", destination);
-        }
 
         if (destination != null) {
             DirUtils.create_with_parents (destination, 0775);


### PR DESCRIPTION
![2019-05-05 10 31 39 の画面録画](https://user-images.githubusercontent.com/26003928/57186847-2bbe3380-6f21-11e9-9f45-d0a2390e2426.gif)

Fixes #20

I'm not sure this solution makes everyone happy, so gonna keep opening this PR for a while. Any opinions like "I prefer the current behavior" or "I like this one" are welcome.

### Current Behavior

At the moment the Recording folder is created when the app runs, because it is necessary to show the default destination to allow users to choose a destination for auto saving in the welcome view.

### Changes Summary

The app automatically disables auto saving when the destination is not set. Once you save your recording, the app set the destination to the folder you choose. After restarting the app, you can enable auto saving by manually.
