### PR TITLE
Save recordings when the app window is destroyed

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -57,7 +57,11 @@ public class Application : Gtk.Application {
         set_accels_for_action ("app.quit", {"<Control>q"});
         quit_action.activate.connect (() => {
             if (window.record_view.is_recording) {
-                window.record_view.stop_recording ();
+                var loop = new MainLoop ();
+                window.record_view.stop_recording.begin ((obj, res) => {
+                    loop.quit ();
+                });
+                loop.run ();
             }
 
             window.destroy ();
@@ -70,7 +74,11 @@ public class Application : Gtk.Application {
             if (window.stack.visible_child_name == "welcome") {
                 window.welcome_view.trigger_recording ();
             } else if (window.stack.visible_child_name == "record") {
-                window.record_view.stop_recording ();
+                var loop = new MainLoop ();
+                window.record_view.stop_recording.begin ((obj, res) => {
+                    loop.quit ();
+                });
+                loop.run ();
             }
         });
     }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -56,32 +56,11 @@ public class Application : Gtk.Application {
         add_action (quit_action);
         set_accels_for_action ("app.quit", {"<Control>q"});
         quit_action.activate.connect (() => {
-            if (!window.record_view.is_recording) {
-                window.destroy ();
-            } else {
-                var warning_dialog = new Granite.MessageDialog.with_image_from_icon_name (
-                    _("Are you sure you want to quit Reco?"),
-                    _("If you quit Reco, the recording in progress will end."),
-                    "dialog-warning", Gtk.ButtonsType.NONE);
-                warning_dialog.transient_for = window;
-                warning_dialog.modal = true;
-                warning_dialog.add_button (_("Cancel"), Gtk.ButtonsType.CANCEL);
-
-                var quit_button = new Gtk.Button.with_label (_("Quit Reco"));
-                quit_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
-                warning_dialog.add_action_widget (quit_button, Gtk.ResponseType.YES);
-
-                warning_dialog.show_all ();
-
-                warning_dialog.response.connect ((response_id) => {
-                    if (response_id == Gtk.ResponseType.YES) {
-                        window.record_view.cancel_recording ();
-                        window.destroy ();
-                    }
-
-                    warning_dialog.destroy ();
-                });
+            if (window.record_view.is_recording) {
+                window.record_view.stop_recording ();
             }
+
+            window.destroy ();
         });
 
         var toggle_recording_action = new SimpleAction ("toggle_recording", null);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -65,7 +65,11 @@ public class MainWindow : Gtk.ApplicationWindow {
 
         delete_event.connect ((event) => {
             if (record_view.is_recording) {
-                record_view.stop_recording ();
+                var loop = new MainLoop ();
+                record_view.stop_recording.begin ((obj, res) => {
+                    loop.quit ();
+                });
+                loop.run ();
             }
 
             return false;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -17,7 +17,6 @@
 
 public class MainWindow : Gtk.ApplicationWindow {
     public Application app { get; construct; }
-    private Gtk.HeaderBar headerbar;
     public Gtk.Stack stack { get; private set; }
     public WelcomeView welcome_view { get; private set; }
     public CountDownView countdown_view { get; private set; }
@@ -41,11 +40,12 @@ public class MainWindow : Gtk.ApplicationWindow {
                                                     cssprovider,
                                                     Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        headerbar = new Gtk.HeaderBar ();
+        var headerbar = new Gtk.HeaderBar ();
         headerbar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         headerbar.get_style_context ().add_class ("default-decoration");
         headerbar.title = "";
         headerbar.has_subtitle = false;
+        headerbar.show_close_button = true;
 
         stack = new Gtk.Stack ();
         welcome_view = new WelcomeView (this);
@@ -71,7 +71,6 @@ public class MainWindow : Gtk.ApplicationWindow {
 
     public void show_welcome () {
         stack.visible_child_name = "welcome";
-        headerbar.show_close_button = true;
     }
 
     public void show_countdown () {
@@ -82,7 +81,6 @@ public class MainWindow : Gtk.ApplicationWindow {
     public void show_record () {
         stack.visible_child_name = "record";
         record_view.start_recording ();
-        headerbar.show_close_button = false;
     }
 
     // Save window position when changed

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -59,6 +59,14 @@ public class MainWindow : Gtk.ApplicationWindow {
         get_style_context ().add_class ("rounded");
         add (stack);
         show_welcome ();
+
+        delete_event.connect ((event) => {
+            if (record_view.is_recording) {
+                record_view.stop_recording ();
+            }
+
+            return false;
+        });
     }
 
     public void show_welcome () {

--- a/src/Views/CountDownView.vala
+++ b/src/Views/CountDownView.vala
@@ -30,7 +30,7 @@ public class CountDownView : Gtk.Box {
 
     construct {
         recording_label = new Gtk.Label (null);
-        recording_label.get_style_context ().add_class ("h2");
+        recording_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
 
         var label_grid = new Gtk.Grid ();
         label_grid.column_spacing = 6;

--- a/src/Views/RecordView.vala
+++ b/src/Views/RecordView.vala
@@ -103,7 +103,11 @@ public class RecordView : Gtk.Box {
         });
 
         stop_button.clicked.connect (() => {
-            stop_recording ();
+            var loop = new MainLoop ();
+            window.record_view.stop_recording.begin ((obj, res) => {
+                loop.quit ();
+            });
+            loop.run ();
         });
 
         pause_button.clicked.connect (() => {
@@ -296,7 +300,7 @@ public class RecordView : Gtk.Box {
         }
     }
 
-    public void stop_recording () {
+    public async void stop_recording () {
         if (count != 0) {
             count = 0;
         }
@@ -441,7 +445,11 @@ public class RecordView : Gtk.Box {
             show_timer_label (remaining_time_label, remain_minutes_10, remain_minutes_1, remain_seconds_10, remain_seconds_1);
 
             if (remain_minutes_10 == 0 && remain_minutes_1 == 0 && remain_seconds_10 == 0 && remain_seconds_1 == 0) {
-                stop_recording ();
+                var loop = new MainLoop ();
+                window.record_view.stop_recording.begin ((obj, res) => {
+                    loop.quit ();
+                });
+                loop.run ();
                 return false;
             }
 

--- a/src/Views/RecordView.vala
+++ b/src/Views/RecordView.vala
@@ -52,10 +52,10 @@ public class RecordView : Gtk.Box {
 
     construct {
         time_label = new Gtk.Label (null);
-        time_label.get_style_context ().add_class ("h2");
+        time_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
 
         remaining_time_label = new Gtk.Label (null);
-        remaining_time_label.get_style_context ().add_class ("h3");
+        remaining_time_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
 
         var label_grid = new Gtk.Grid ();
         label_grid.column_spacing = 6;

--- a/src/Views/RecordView.vala
+++ b/src/Views/RecordView.vala
@@ -148,7 +148,6 @@ public class RecordView : Gtk.Box {
                     try {
                         var uri = File.new_for_path (destination + "/" + filename + suffix);
                         tmp_source.move (uri, FileCopyFlags.OVERWRITE);
-                        window.welcome_view.show_success_button ();
                     } catch (Error e) {
                         stderr.printf ("Error: %s\n", e.message);
                     }
@@ -164,7 +163,6 @@ public class RecordView : Gtk.Box {
                         try {
                             var uri = File.new_for_path (filechooser.get_filename ());
                             tmp_source.move (uri, FileCopyFlags.OVERWRITE);
-                            window.welcome_view.show_success_button ();
                         } catch (Error e) {
                             stderr.printf ("Error: %s\n", e.message);
                         }
@@ -316,7 +314,9 @@ public class RecordView : Gtk.Box {
             pause_button.tooltip_text = _("Pause recording");
         }
 
-        pipeline.send_event (new Gst.Event.eos ());
+        if (pipeline.send_event (new Gst.Event.eos ())) {
+            window.welcome_view.show_success_button ();
+        }
 
         window.show_welcome ();
         is_recording = false;


### PR DESCRIPTION
Fixes #34

## TODO

* [x] Fix the following error message is shown when the app window is destroyed:

```
(com.github.ryonakano.reco:6864): Gtk-CRITICAL **: 19:36:42.253: gtk_widget_get_parent: assertion 'GTK_IS_WIDGET (widget)' failed
```

* [x] Fix the segmentation fault when auto-saving is disabled
