### PR TITLE
Flatpak: Add runtime dependency gst-libav for avenc_aac

### DIFF
--- a/com.github.ryonakano.reco.yml
+++ b/com.github.ryonakano.reco.yml
@@ -10,6 +10,7 @@ finish-args:
   - '--socket=wayland'
   - '--socket=fallback-x11'
   - '--socket=pulseaudio'
+  - '--env=GST_PLUGIN_PATH_1_0=/app/lib/gstreamer-1.0'
 
   - '--filesystem=/tmp/com.github.ryonakano.reco:create'
   - '--env=TMPDIR=/tmp/com.github.ryonakano.reco'
@@ -20,7 +21,9 @@ finish-args:
   - '--metadata=X-DConf=migrate-path=/com/github/ryonakano/reco/'
 modules:
   - name: gst-libav
-    buildsystem: meson
+    buildsystem: autotools
+    config-opts:
+      - --with-system-libav=no
     sources:
       - type: git
         url: git://anongit.freedesktop.org/gstreamer/gst-libav

--- a/com.github.ryonakano.reco.yml
+++ b/com.github.ryonakano.reco.yml
@@ -19,6 +19,12 @@ finish-args:
 
   - '--metadata=X-DConf=migrate-path=/com/github/ryonakano/reco/'
 modules:
+  - name: gst-libav
+    buildsystem: meson
+    sources:
+      - type: git
+        url: git://anongit.freedesktop.org/gstreamer/gst-libav
+        tag: '1.16'
   - name: reco
     buildsystem: meson
     sources:


### PR DESCRIPTION
If you choose AAC for the file format, the app crashes when you start recording and get the following error message:

```
** (com.github.ryonakano.reco:2): ERROR **: 17:01:02.062: Recorder.vala:118: The GStreamer element encoder was not created correctly
```

This PR adds `gst-libav` which should include `avenc_aac` but it does not work for some reason.
