### PR TITLE
Recorder: Clean code

### DIFF
--- a/src/Services/DeviceManager.vala
+++ b/src/Services/DeviceManager.vala
@@ -70,14 +70,14 @@ public class DeviceManager : Object {
             switch (properties.get_string ("device.class")) {
                 case "sound":
                     if (!microphones.contains (device)) {
-                        debug ("Microphone detected: %s", device.display_name);
+                        debug ("Microphone detected: \"%s\"", device.display_name);
                         microphones.add (device);
                     }
 
                     break;
                 case "monitor":
                     if (!monitors.contains (device)) {
-                        debug ("Monitor detected: %s", device.display_name);
+                        debug ("Monitor detected: \"%s\"", device.display_name);
                         monitors.add (device);
                     }
 

--- a/src/Services/Recorder.vala
+++ b/src/Services/Recorder.vala
@@ -54,7 +54,7 @@ public class Recorder : Object {
         if (source != Source.MIC) {
             // TODO: How to fetch the default monitor?
             Gst.Device monitor = DeviceManager.get_default ().monitors.get (0);
-            sys_sound = monitor.create_element ("mic_sound");
+            sys_sound = monitor.create_element ("sys_sound");
             if (sys_sound == null) {
                 error ("The GStreamer element pulsesrc (named \"sys_sound\") was not created correctly");
             }


### PR DESCRIPTION
- Use `Gst.Device.create_element` instead of `Gst.Device.reconfigure_element` to remove double check for `Source`
- Explicit nullable
- Put `display_name` in quotation marks
