### PR TITLE
MainWindow: Don't use Granite's const for default decoration

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -92,7 +92,7 @@ public class MainWindow : Hdy.Window {
 
         var headerbar_style_context = headerbar.get_style_context ();
         headerbar_style_context.add_class (Gtk.STYLE_CLASS_FLAT);
-        headerbar_style_context.add_class (Granite.STYLE_CLASS_DEFAULT_DECORATION);
+        headerbar_style_context.add_class ("default-decoration");
 
         welcome_view = new WelcomeView (this);
         countdown_view = new CountDownView (this);


### PR DESCRIPTION
Reverts a change in #123
Fixes #125

This const is only available on Granite 6.0.0 or later, which cause the build failing on Debian 11. We should revert this change for now.
