### PR TITLE
Flatpak: Revoke access to AccountsService

### DIFF
--- a/com.github.ryonakano.reco.yml
+++ b/com.github.ryonakano.reco.yml
@@ -11,10 +11,6 @@ finish-args:
   - '--socket=fallback-x11'
   - '--socket=pulseaudio'
   - '--env=GST_PLUGIN_PATH_1_0=/app/lib/gstreamer-1.0'
-
-  # needed for perfers-color-scheme
-  - '--system-talk-name=org.freedesktop.Accounts'
-
   - '--metadata=X-DConf=migrate-path=/com/github/ryonakano/reco/'
 modules:
   - name: gst-libav


### PR DESCRIPTION
We don't need this since Flatpak Platform 6.0.2
