### PR TITLE
GTK: Replace deprecated Gtk.StyleContext.add_class / remove_class

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -64,10 +64,8 @@ public class MainWindow : Gtk.ApplicationWindow {
         };
         headerbar.pack_end (preferences_button);
         set_titlebar (headerbar);
-
-        var headerbar_style_context = headerbar.get_style_context ();
-        headerbar_style_context.add_class (Granite.STYLE_CLASS_FLAT);
-        headerbar_style_context.add_class (Granite.STYLE_CLASS_DEFAULT_DECORATION);
+        headerbar.add_css_class (Granite.STYLE_CLASS_FLAT);
+        headerbar.add_css_class (Granite.STYLE_CLASS_DEFAULT_DECORATION);
 
         welcome_view = new WelcomeView (this);
         countdown_view = new CountDownView (this);

--- a/src/Views/CountDownView.vala
+++ b/src/Views/CountDownView.vala
@@ -26,7 +26,7 @@ public class CountDownView : Gtk.Box {
 
     construct {
         delay_remaining_label = new Gtk.Label (null);
-        delay_remaining_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
+        delay_remaining_label.add_css_class (Granite.STYLE_CLASS_H2_LABEL);
 
         var label_grid = new Gtk.Grid () {
             column_spacing = 6,
@@ -41,14 +41,14 @@ public class CountDownView : Gtk.Box {
             tooltip_text = _("Cancel the countdown"),
             halign = Gtk.Align.START
         };
-        cancel_button.get_style_context ().add_class ("buttons-without-border");
+        cancel_button.add_css_class ("buttons-without-border");
 
         pause_button = new Gtk.Button () {
             icon_name = "media-playback-pause-symbolic",
             tooltip_text = _("Pause the countdown"),
             halign = Gtk.Align.END
         };
-        pause_button.get_style_context ().add_class ("buttons-without-border");
+        pause_button.add_css_class ("buttons-without-border");
 
         var buttons_grid = new Gtk.Grid () {
             column_spacing = 30,

--- a/src/Views/RecordView.vala
+++ b/src/Views/RecordView.vala
@@ -38,10 +38,10 @@ public class RecordView : Gtk.Box {
         recorder = Recorder.get_default ();
 
         time_label = new Gtk.Label (null);
-        time_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
+        time_label.add_css_class (Granite.STYLE_CLASS_H2_LABEL);
 
         remaining_time_label = new Gtk.Label (null);
-        remaining_time_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
+        remaining_time_label.add_css_class (Granite.STYLE_CLASS_H3_LABEL);
 
         var label_grid = new Gtk.Grid () {
             column_spacing = 6,
@@ -57,7 +57,7 @@ public class RecordView : Gtk.Box {
             tooltip_text = _("Cancel recording"),
             halign = Gtk.Align.START
         };
-        cancel_button.get_style_context ().add_class ("buttons-without-border");
+        cancel_button.add_css_class ("buttons-without-border");
 
         stop_button = new Gtk.Button () {
             icon_name = "media-playback-stop-symbolic",
@@ -66,7 +66,7 @@ public class RecordView : Gtk.Box {
             width_request = 48,
             height_request = 48
         };
-        stop_button.get_style_context ().add_class ("record-button");
+        stop_button.add_css_class ("record-button");
         ((Gtk.Image) stop_button.child).icon_size = Gtk.IconSize.LARGE;
 
         pause_button = new Gtk.Button () {
@@ -74,7 +74,7 @@ public class RecordView : Gtk.Box {
             tooltip_text = _("Pause recording"),
             halign = Gtk.Align.END
         };
-        pause_button.get_style_context ().add_class ("buttons-without-border");
+        pause_button.add_css_class ("buttons-without-border");
 
         var buttons_grid = new Gtk.Grid () {
             column_spacing = 30,

--- a/src/Views/WelcomeView.vala
+++ b/src/Views/WelcomeView.vala
@@ -141,7 +141,7 @@ public class WelcomeView : Gtk.Box {
             width_request = 48,
             height_request = 48
         };
-        record_button.get_style_context ().add_class ("record-button");
+        record_button.add_css_class ("record-button");
         ((Gtk.Image) record_button.child).icon_size = Gtk.IconSize.LARGE;
 
         append (settings_grid);
@@ -245,10 +245,10 @@ public class WelcomeView : Gtk.Box {
     }
 
     public void show_success_button () {
-        record_button.get_style_context ().add_class ("record-button-success");
+        record_button.add_css_class ("record-button-success");
         record_button.icon_name = "record-completed-symbolic";
         uint timeout_button_color = Timeout.add (3000, () => {
-            record_button.get_style_context ().remove_class ("record-button-success");
+            record_button.remove_css_class ("record-button-success");
             return false;
         });
         timeout_button_color = 0;


### PR DESCRIPTION
From https://valadoc.org/gtk4/Gtk.StyleContext.html:

> Warning: StyleContext is deprecated since 4.10.
>
> `GtkStyleContext` stores styling information affecting a widget.
>
> Note:
> The relevant API has been moved to [class@Gtk.Widget] where applicable; otherwise, there is no replacement for querying the style machinery. Stylable UI elements should use widgets.

Regarding to `Gtk.StyleContext.add_provider_for_display`, it's not clear if it's deprecated or not from [the doc](https://docs.gtk.org/gtk4/type_func.StyleContext.add_provider_for_display.html) so leaving it as it is for now.