### PR TITLE
Application: Fix redundant load of icon

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -145,10 +145,6 @@ public class Application : Gtk.Application {
                                                    cssprovider,
                                                    Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        // Load GResource for our custom icons
-        var icon_theme = Gtk.IconTheme.get_for_display (display);
-        icon_theme.add_resource_path ("/com/github/ryonakano/reco");
-
         setup_style ();
     }
 


### PR DESCRIPTION
From https://docs.gtk.org/gtk4/class.Application.html

> GtkApplication will also automatically setup an icon search path for the default icon theme by appending “icons” to the resource base path.