### PR TITLE
Application: Remove TODO about deprecation of Gtk.StyleContext.add_provider_for_display

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -140,7 +140,6 @@ public class Application : Gtk.Application {
 
         var cssprovider = new Gtk.CssProvider ();
         cssprovider.load_from_resource ("/com/github/ryonakano/reco/Application.css");
-        // TODO: Deprecated in Gtk 4.10, buit no alternative api is provided so leave it for now
         Gtk.StyleContext.add_provider_for_display (display,
                                                    cssprovider,
                                                    Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);


### PR DESCRIPTION
This static method is not deprecated in Gtk4 at this moment actually and it seems to be an error in Vala:

https://docs.gtk.org/gtk4/type_func.StyleContext.add_provider_for_display.html https://gitlab.gnome.org/GNOME/vala/-/commit/e6bc168ce69b16437ac5556fe537675ab2cd189f