### PR TITLE
chore: metainfo: Update license id

### DIFF
--- a/data/reco.metainfo.xml.in.in
+++ b/data/reco.metainfo.xml.in.in
@@ -5,7 +5,7 @@
   <launchable type="desktop-id">@APP_ID@.desktop</launchable>
   <translation type="gettext">@GETTEXT_PACKAGE@</translation>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0+</project_license>
+  <project_license>GPL-3.0-or-later</project_license>
 
   <name translate="no">Reco</name>
   <summary>Focus on recording</summary>


### PR DESCRIPTION
Since `GPL-3.0+` is deprecated.

https://spdx.org/licenses/GPL-3.0+.html