### PR TITLE
Flatpak: Use git for modules

### DIFF
--- a/build-aux/appcenter/com.github.ryonakano.reco.Devel.yml
+++ b/build-aux/appcenter/com.github.ryonakano.reco.Devel.yml
@@ -14,9 +14,10 @@ modules:
   - name: live-chart
     buildsystem: meson
     sources:
-      - type: archive
-        url: https://github.com/lcallarec/live-chart/archive/refs/tags/1.10.0.tar.gz
-        sha256: 3f54c7569cc2a4711b5689038055aefc4321636f3e6dd4945e4be204bc9d4843
+      - type: git
+        url: https://github.com/lcallarec/live-chart.git
+        tag: 1.10.0
+        commit: 41e5803e61162d80a06974eebc67a511cc22e83d
 
   - name: gst-libav
     buildsystem: meson
@@ -31,9 +32,10 @@ modules:
   - name: ryokucha
     buildsystem: meson
     sources:
-      - type: archive
-        url: https://github.com/ryonakano/ryokucha/archive/refs/tags/0.3.1.tar.gz
-        sha256: 503754d1a0a9012e5779f20ef1e9bb7db099eb9243bc98985b2136e4e1b0031e
+      - type: git
+        url: https://github.com/ryonakano/ryokucha.git
+        tag: 0.3.1
+        commit: 781f43d5c539bfe77c72fbaa32fc589a02b03c40
 
   - name: reco
     buildsystem: meson

--- a/com.github.ryonakano.reco.yml
+++ b/com.github.ryonakano.reco.yml
@@ -15,9 +15,10 @@ modules:
   - name: live-chart
     buildsystem: meson
     sources:
-      - type: archive
-        url: https://github.com/lcallarec/live-chart/archive/refs/tags/1.10.0.tar.gz
-        sha256: 3f54c7569cc2a4711b5689038055aefc4321636f3e6dd4945e4be204bc9d4843
+      - type: git
+        url: https://github.com/lcallarec/live-chart.git
+        tag: 1.10.0
+        commit: 41e5803e61162d80a06974eebc67a511cc22e83d
 
   - name: gst-libav
     buildsystem: meson
@@ -32,9 +33,10 @@ modules:
   - name: ryokucha
     buildsystem: meson
     sources:
-      - type: archive
-        url: https://github.com/ryonakano/ryokucha/archive/refs/tags/0.3.1.tar.gz
-        sha256: 503754d1a0a9012e5779f20ef1e9bb7db099eb9243bc98985b2136e4e1b0031e
+      - type: git
+        url: https://github.com/ryonakano/ryokucha.git
+        tag: 0.3.1
+        commit: 781f43d5c539bfe77c72fbaa32fc589a02b03c40
 
   - name: reco
     buildsystem: meson


### PR DESCRIPTION
I prefer archives for quick download but that should be a tiny difference in the modern fast networks

Leaving gst-livav as archive because its git is the single gstreamer repository which is big and waste of time and network traffic to download