### PR TITLE
Flatpak: Use id instead of deprecated app-id

### DIFF
--- a/build-aux/appcenter/com.github.ryonakano.reco.Devel.yml
+++ b/build-aux/appcenter/com.github.ryonakano.reco.Devel.yml
@@ -1,4 +1,4 @@
-app-id: com.github.ryonakano.reco.Devel
+id: com.github.ryonakano.reco.Devel
 runtime: io.elementary.Platform
 runtime-version: '8'
 sdk: io.elementary.Sdk

--- a/com.github.ryonakano.reco.yml
+++ b/com.github.ryonakano.reco.yml
@@ -1,4 +1,4 @@
-app-id: com.github.ryonakano.reco
+id: com.github.ryonakano.reco
 runtime: io.elementary.Platform
 runtime-version: '8'
 sdk: io.elementary.Sdk


### PR DESCRIPTION
From https://docs.flatpak.org/en/latest/flatpak-builder-command-reference.html:

> Note, "app-id" is deprecated and preserved only for backwards compatibility.