### PR TITLE
refactor: Obtain delay length from spinner directly instead of GSettings

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -77,7 +77,13 @@ public class MainWindow : Adw.ApplicationWindow {
 
         show_welcome ();
 
-        welcome_view.start_recording.connect (start_wrapper);
+        welcome_view.start_recording.connect ((delay_sec) => {
+            if (delay_sec > 0) {
+                show_countdown (delay_sec);
+            } else {
+                show_record ();
+            }
+        });
 
         countdown_view.countdown_cancelled.connect (show_welcome);
         countdown_view.countdown_ended.connect (show_record);
@@ -231,14 +237,6 @@ public class MainWindow : Adw.ApplicationWindow {
 
         record_view.refresh_begin ();
         stack.visible_child = record_view;
-    }
-
-    private void start_wrapper (uint delay_sec) {
-        if (delay_sec > 0) {
-            show_countdown (delay_sec);
-        } else {
-            show_record ();
-        }
     }
 
     public bool check_destroy () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -211,8 +211,8 @@ public class MainWindow : Adw.ApplicationWindow {
         stack.visible_child = welcome_view;
     }
 
-    private void show_countdown () {
-        countdown_view.init_countdown ();
+    private void show_countdown (uint sec) {
+        countdown_view.init_countdown (sec);
         countdown_view.start_countdown ();
         stack.visible_child = countdown_view;
     }
@@ -233,10 +233,9 @@ public class MainWindow : Adw.ApplicationWindow {
         stack.visible_child = record_view;
     }
 
-    private void start_wrapper () {
-        uint delay = Application.settings.get_uint ("delay");
-        if (delay != 0) {
-            show_countdown ();
+    private void start_wrapper (uint delay_sec) {
+        if (delay_sec > 0) {
+            show_countdown (delay_sec);
         } else {
             show_record ();
         }

--- a/src/View/CountDownView.vala
+++ b/src/View/CountDownView.vala
@@ -80,11 +80,10 @@ public class View.CountDownView : AbstractView {
         });
     }
 
-    public void init_countdown () {
+    public void init_countdown (uint sec) {
         delaytimer.init ();
 
-        uint delay_length = Application.settings.get_uint ("delay");
-        delaytimer.seek (delay_length);
+        delaytimer.seek (sec);
         delay_remaining_label.label = delaytimer.to_string ();
 
         pause_button_set_pause ();

--- a/src/View/WelcomeView.vala
+++ b/src/View/WelcomeView.vala
@@ -4,7 +4,7 @@
  */
 
 public class View.WelcomeView : AbstractView {
-    public signal void start_recording ();
+    public signal void start_recording (uint delay_sec);
 
     private unowned Manager.DeviceManager device_manager;
 
@@ -13,6 +13,7 @@ public class View.WelcomeView : AbstractView {
 
     private Ryokucha.DropDownText source_combobox;
     private Ryokucha.DropDownText mic_combobox;
+    private Gtk.SpinButton delay_spin;
     private Gtk.Switch autosave_switch;
     private Widget.FolderChooserButton destination_chooser_button;
     private Gtk.Button record_button;
@@ -65,7 +66,7 @@ public class View.WelcomeView : AbstractView {
         var delay_label = new Gtk.Label (_("Delay in seconds:")) {
             halign = Gtk.Align.END
         };
-        var delay_spin = new Gtk.SpinButton.with_range (0, 15, 1) {
+        delay_spin = new Gtk.SpinButton.with_range (0, 15, 1) {
             halign = Gtk.Align.START
         };
 
@@ -188,7 +189,7 @@ public class View.WelcomeView : AbstractView {
                             // Only start recording when recording source is connected
                             bool is_connected = get_is_source_connected ();
                             if (is_connected) {
-                                start_recording ();
+                                start_recording ((uint) delay_spin.value);
                             }
 
                             return Gdk.EVENT_STOP;
@@ -213,7 +214,7 @@ public class View.WelcomeView : AbstractView {
         destination_chooser_button.folder_set.connect (remember_autosave_dir);
 
         record_button.clicked.connect (() => {
-            start_recording ();
+            start_recording ((uint) delay_spin.value);
         });
 
         device_manager.device_updated.connect (() => {


### PR DESCRIPTION
Getting delay length from GSettings here is just a waste of method call
