### PR TITLE
docs: Default for Flathub, optionally for AppCenter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ We accept changes to the source code through pull requests―even a small typo f
 
 ### Coding Style
 
-We follow [the coding style of elementary OS](https://docs.elementary.io/develop/writing-apps/code-style) and [its Human Interface Guidelines](https://docs.elementary.io/hig/). Try to respect them.
+We follow [the coding style of elementary OS](https://docs.elementary.io/develop/writing-apps/code-style). Try to respect them.
 
 ## Manage the Project
 

--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ Community packages maintained by volunteers are also available on some distribut
 ### From Source Code (Flatpak)
 You'll need `flatpak` and `flatpak-builder` commands installed on your system.
 
-Run `flatpak remote-add` to add AppCenter remote for dependencies:
+Run `flatpak remote-add` to add Flathub remote for dependencies:
 
 ```
-flatpak remote-add --user --if-not-exists appcenter https://flatpak.elementary.io/repo.flatpakrepo
+flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 ```
 
 To build and install, use `flatpak-builder`, then execute with `flatpak run`:
 
 ```
-flatpak-builder builddir --user --install --force-clean --install-deps-from=appcenter build-aux/appcenter/com.github.ryonakano.reco.Devel.yml
+flatpak-builder builddir --user --install --force-clean --install-deps-from=flathub build-aux/flathub/com.github.ryonakano.reco.Devel.yml
 flatpak run com.github.ryonakano.reco.Devel
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Reco
-![Welcome view in the light mode](data/screenshots/pantheon/welcome-init-light.png#gh-light-mode-only) ![Recording view in the light mode](data/screenshots/pantheon/recording-light.png#gh-light-mode-only)
+![Welcome view in the light mode](data/screenshots/gnome/welcome-init-light.png#gh-light-mode-only) ![Recording view in the light mode](data/screenshots/gnome/recording-light.png#gh-light-mode-only)
 
-![Welcome view in the dark mode](data/screenshots/pantheon/welcome-init-dark.png#gh-dark-mode-only) ![Recording view in the dark mode](data/screenshots/pantheon/recording-dark.png#gh-dark-mode-only)
+![Welcome view in the dark mode](data/screenshots/gnome/welcome-init-dark.png#gh-dark-mode-only) ![Recording view in the dark mode](data/screenshots/gnome/recording-dark.png#gh-dark-mode-only)
 
 Reco is an audio recorder focused on being concise and simple to use.
 
@@ -16,14 +16,14 @@ Features include:
 * **Saving recordings when the app quits.** Even if you happen to quit the app while recording, the recording is either saved automatically, or the file chooser dialog is shown - depending on your preferences.
 
 ## Installation
-### From AppCenter or Flathub (Recommended)
-Click the button to get Reco on AppCenter if you're on elementary OS:
-
-[![Get it on AppCenter](https://appcenter.elementary.io/badge.svg)](https://appcenter.elementary.io/com.github.ryonakano.reco)
-
-You can install Reco from Flathub if you're on another distribution:
+### From Flathub or AppCenter (Recommended)
+You can install Reco from Flathub:
 
 [<img src="https://flathub.org/assets/badges/flathub-badge-en.svg" width="160" alt="Download on Flathub">](https://flathub.org/apps/com.github.ryonakano.reco)
+
+You should install Reco from AppCenter if you're on elementary OS. This build is optimized for elementary OS:
+
+[![Get it on AppCenter](https://appcenter.elementary.io/badge.svg)](https://appcenter.elementary.io/com.github.ryonakano.reco)
 
 ### From Community Packages
 Community packages maintained by volunteers are also available on some distributions:


### PR DESCRIPTION
As we did #308 and #310, we now target Flathub by default and optionally build for AppCenter.
