### PR TITLE
feat: Improve filename

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -178,19 +178,22 @@ public class MainWindow : Adw.ApplicationWindow {
     }
 
     private string build_filename_from_datetime (DateTime start, DateTime end, string suffix) {
-        string start_format = start.format ("%Y-%m-%d_%H:%M:%S");
-        string end_format = end.format ("%Y-%m-%d_%H:%M:%S");
+        string start_format = "%Y-%m-%d_%H:%M:%S";
+        string end_format = "%Y-%m-%d_%H:%M:%S";
 
         bool is_same_day = Util.is_same_day (start, end);
         if (is_same_day) {
             // Avoid redundant date
-            end_format = end.format ("%H:%M:%S");
+            end_format = "%H:%M:%S";
         }
+
+        string start_str = start.format (start_format);
+        string end_str = end.format (end_format);
 
         //TRANSLATORS: This is the format of filename and %s represents a timestamp here.
         //Suffix is automatically appended depending on the recording format.
         //e.g. "2018-11-10_23:42:36 to 2018-11-11_07:13:50.wav"
-        return _("%s to %s").printf (start_format, end_format) + suffix;
+        return _("%s to %s").printf (start_str, end_str) + suffix;
     }
 
     /**

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -132,8 +132,8 @@ public class MainWindow : Adw.ApplicationWindow {
 
             //TRANSLATORS: This is the format of filename and %s represents a timestamp here.
             //Suffix is automatically appended depending on the recording format.
-            //e.g. "Recording from 2018-11-10_23:42:36 to 2018-11-11_07:13:50.wav"
-            string default_filename = _("Recording from %s to %s").printf (
+            //e.g. "2018-11-10_23:42:36 to 2018-11-11_07:13:50.wav"
+            string default_filename = _("%s to %s").printf (
                                           recorder.start_dt.format ("%Y-%m-%d_%H:%M:%S")
                                         , recorder.end_dt.format ("%Y-%m-%d_%H:%M:%S")
                                     ) + suffix;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -129,12 +129,14 @@ public class MainWindow : Adw.ApplicationWindow {
 
             string suffix = Util.get_suffix (tmp_path);
             var tmp_file = File.new_for_path (tmp_path);
-            var end_dt = new DateTime.now_local ();
 
             //TRANSLATORS: This is the format of filename and %s represents a timestamp here.
             //Suffix is automatically appended depending on the recording format.
-            //e.g. "Recording from 2018-11-10 23.42.36.wav"
-            string default_filename = _("Recording from %s").printf (end_dt.format ("%Y-%m-%d %H.%M.%S")) + suffix;
+            //e.g. "Recording from 2018-11-10_23:42:36 to 2018-11-11_07:13:50.wav"
+            string default_filename = _("Recording from %s to %s").printf (
+                                          recorder.start_dt.format ("%Y-%m-%d_%H:%M:%S")
+                                        , recorder.end_dt.format ("%Y-%m-%d_%H:%M:%S")
+                                    ) + suffix;
 
             ask_save_path.begin (default_filename, (obj, res) => {
                 File? save_path = ask_save_path.end (res);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -130,13 +130,7 @@ public class MainWindow : Adw.ApplicationWindow {
             string suffix = Util.get_suffix (tmp_path);
             var tmp_file = File.new_for_path (tmp_path);
 
-            //TRANSLATORS: This is the format of filename and %s represents a timestamp here.
-            //Suffix is automatically appended depending on the recording format.
-            //e.g. "2018-11-10_23:42:36 to 2018-11-11_07:13:50.wav"
-            string default_filename = _("%s to %s").printf (
-                                          recorder.start_dt.format ("%Y-%m-%d_%H:%M:%S")
-                                        , recorder.end_dt.format ("%Y-%m-%d_%H:%M:%S")
-                                    ) + suffix;
+            string default_filename = build_filename_from_datetime (recorder.start_dt, recorder.end_dt, suffix);
 
             ask_save_path.begin (default_filename, (obj, res) => {
                 File? save_path = ask_save_path.end (res);
@@ -181,6 +175,22 @@ public class MainWindow : Adw.ApplicationWindow {
                 }
             });
         });
+    }
+
+    private string build_filename_from_datetime (DateTime start, DateTime end, string suffix) {
+        string start_format = start.format ("%Y-%m-%d_%H:%M:%S");
+        string end_format = end.format ("%Y-%m-%d_%H:%M:%S");
+
+        bool is_same_day = Util.is_same_day (start, end);
+        if (is_same_day) {
+            // Avoid redundant date
+            end_format = end.format ("%H:%M:%S");
+        }
+
+        //TRANSLATORS: This is the format of filename and %s represents a timestamp here.
+        //Suffix is automatically appended depending on the recording format.
+        //e.g. "2018-11-10_23:42:36 to 2018-11-11_07:13:50.wav"
+        return _("%s to %s").printf (start_format, end_format) + suffix;
     }
 
     /**

--- a/src/Model/Recorder.vala
+++ b/src/Model/Recorder.vala
@@ -83,8 +83,8 @@ namespace Model {
         private double _current_peak = 0;
 
         private string tmp_path;
-        public DateTime start_dt { get; private set ; }
-        public DateTime end_dt { get; private set ; }
+        public DateTime start_dt { get; private set; }
+        public DateTime end_dt { get; private set; }
         private Gst.Pipeline pipeline;
         private uint inhibit_token = 0;
         private const uint64 NSEC = 1000000000;

--- a/src/Model/Recorder.vala
+++ b/src/Model/Recorder.vala
@@ -83,6 +83,8 @@ namespace Model {
         private double _current_peak = 0;
 
         private string tmp_path;
+        public DateTime start_dt { get; private set ; }
+        public DateTime end_dt { get; private set ; }
         private Gst.Pipeline pipeline;
         private uint inhibit_token = 0;
         private const uint64 NSEC = 1000000000;
@@ -218,7 +220,7 @@ namespace Model {
                 }
             }
 
-            var start_dt = new DateTime.now_local ();
+            start_dt = new DateTime.now_local ();
             string tmp_filename = "reco_%s%s".printf (start_dt.to_unix ().to_string (), fmt_data.suffix);
             tmp_path = Path.build_filename (Environment.get_user_cache_dir (), tmp_filename);
             sink.set ("location", tmp_path);
@@ -265,6 +267,7 @@ namespace Model {
                 case Gst.MessageType.EOS:
                     state = RecordingState.STOPPED;
                     pipeline.dispose ();
+                    end_dt = new DateTime.now_local ();
 
                     save_file (tmp_path);
                     break;

--- a/src/Util.vala
+++ b/src/Util.vala
@@ -18,6 +18,32 @@ namespace Util {
         return path.substring (suffix_index);
     }
 
+    public static bool is_same_day (DateTime a, DateTime b) {
+        int a_year;
+        int a_month;
+        int a_day;
+        int b_year;
+        int b_month;
+        int b_day;
+
+        a.get_ymd (out a_year, out a_month, out a_day);
+        b.get_ymd (out b_year, out b_month, out b_day);
+
+        if (a_day != b_day) {
+            return false;
+        }
+
+        if (a_month != b_month) {
+            return false;
+        }
+
+        if (a_year != b_year) {
+            return false;
+        }
+
+        return true;
+    }
+
     public static Adw.ColorScheme to_adw_scheme (string str_scheme) {
         switch (str_scheme) {
             case Define.ColorScheme.DEFAULT:


### PR DESCRIPTION
Fixes #289

- Include both start and end date time in filenames
- Remove redundant prefix "Recording from"
