### PR TITLE
fix: Support recording from Bluetooth devices

### DIFF
--- a/src/Manager/DeviceManager.vala
+++ b/src/Manager/DeviceManager.vala
@@ -71,12 +71,13 @@ public class Manager.DeviceManager : Object {
         foreach (var device in monitor.get_devices ()) {
             Gst.Structure properties = device.properties;
 
-            if (properties.get_string ("device.class") != "sound") {
-                continue;
-            }
-
             if (device.has_classes (CLASS_NAME_SOURCE)) {
                 if (sources.contains (device)) {
+                    continue;
+                }
+
+                // We manually build device names of monitors so don't add them as a source here
+                if (properties.get_string ("device.class") == "monitor") {
                     continue;
                 }
 


### PR DESCRIPTION
Fixes #282

We're too strict to detect input/output devices and resulting ignoring Bluetooth devices.

## Checklist
I connect my AirPods Pro 2 to Fedora 43 and confirmed:

- [x] Bluetooth input is listed in the sources list
- [x] Possible to record from a microphone while using Bluetooth input
- [x] Possible to record from system while using Bluetooth output
