### PR TITLE
chore: Flatpak: Correct x-checker-data of taglib

### DIFF
--- a/build-aux/appcenter/com.github.ryonakano.reco.Devel.yml
+++ b/build-aux/appcenter/com.github.ryonakano.reco.Devel.yml
@@ -48,8 +48,8 @@ modules:
             x-checker-data:
               type: json
               url: https://api.github.com/repos/taglib/taglib/releases/latest
-              version-query: .tag_name
-              url-query: '.assets[] | select(.name==\"taglib-\" + $version + \".tar.gz\") | .browser_download_url'
+              version-query: '.tag_name | sub("v"; "")'
+              url-query: '.assets[] | select(.name=="taglib-" + $version + ".tar.gz") | .browser_download_url'
               timestamp-query: .published_at
 
   - name: gst-libav

--- a/build-aux/flathub/com.github.ryonakano.reco.Devel.yml
+++ b/build-aux/flathub/com.github.ryonakano.reco.Devel.yml
@@ -48,8 +48,8 @@ modules:
             x-checker-data:
               type: json
               url: https://api.github.com/repos/taglib/taglib/releases/latest
-              version-query: .tag_name
-              url-query: '.assets[] | select(.name==\"taglib-\" + $version + \".tar.gz\") | .browser_download_url'
+              version-query: '.tag_name | sub("v"; "")'
+              url-query: '.assets[] | select(.name=="taglib-" + $version + ".tar.gz") | .browser_download_url'
               timestamp-query: .published_at
 
   - name: gst-libav

--- a/com.github.ryonakano.reco.yml
+++ b/com.github.ryonakano.reco.yml
@@ -49,8 +49,8 @@ modules:
             x-checker-data:
               type: json
               url: https://api.github.com/repos/taglib/taglib/releases/latest
-              version-query: .tag_name
-              url-query: '.assets[] | select(.name==\"taglib-\" + $version + \".tar.gz\") | .browser_download_url'
+              version-query: '.tag_name | sub("v"; "")'
+              url-query: '.assets[] | select(.name=="taglib-" + $version + ".tar.gz") | .browser_download_url'
               timestamp-query: .published_at
 
   - name: gst-libav


### PR DESCRIPTION
Fixes GitHub Actions is failing with the following error:

https://github.com/ryonakano/reco/actions/runs/22288740034/job/64472037373

```
INFO    src.manifest: Checking 5 external data items
INFO    src.manifest: Started check [1/5] archive live-chart/1.10.0.tar.gz (from com.github.ryonakano.reco.Devel.yml)
INFO    src.manifest: Started check [2/5] archive taglib/taglib-2.1.1.tar.gz (from com.github.ryonakano.reco.Devel.yml)
INFO    src.manifest: Skipped check [3/5] archive gst-plugins-good/gst-plugins-good-1.24.12.tar.xz (from com.github.ryonakano.reco.Devel.yml)
INFO    src.manifest: Skipped check [4/5] archive gst-libav/gst-libav-1.24.12.tar.xz (from com.github.ryonakano.reco.Devel.yml)
INFO    src.manifest: Started check [5/5] archive ryokucha/0.3.1.tar.gz (from com.github.ryonakano.reco.Devel.yml)
jq: error: syntax error, unexpected INVALID_CHARACTER (Unix shell quoting issues?) at <top-level>, line 1:
.assets[] | select(.name==\"taglib-\" + $version + \".tar.gz\") | .browser_download_url                          
jq: 1 compile error
ERROR   src.manifest: Failed to check archive taglib/taglib-2.1.1.tar.gz with JSONChecker: Error running jq: Command '['jq', '--argjson', 'version', '"v2.2"', '-e', '.assets[] | select(.name==\\"taglib-\\" + $version + \\".tar.gz\\") | .browser_download_url']' returned non-zero exit status 3.
INFO    src.manifest: Finished check [4/5] archive live-chart/1.10.0.tar.gz (from com.github.ryonakano.reco.Devel.yml)
INFO    src.manifest: Finished check [5/5] archive ryokucha/0.3.1.tar.gz (from com.github.ryonakano.reco.Devel.yml)
WARNING src.main: Check finished with 1 error(s)
```