### PR TITLE
chore: Review all copies

### DIFF
--- a/data/ui/help-overlay.blp
+++ b/data/ui/help-overlay.blp
@@ -24,7 +24,7 @@ ShortcutsWindow help_overlay {
             title: C_("shortcut window", "Recording");
 
             ShortcutsShortcut {
-                title: C_("shortcut window", "Start/Stop recording");
+                title: C_("shortcut window", "Start/Stop Recording");
                 accelerator: "<Shift><Ctrl>R";
             }
         }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -24,8 +24,8 @@ public class MainWindow : Adw.ApplicationWindow {
 
     static construct {
         starterr_message_table = new Gee.HashMap<int, string> ();
-        starterr_message_table[Define.RecordError.CREATE_ERROR] = N_("This is possibly due to missing codecs or incomplete installation of the app. Make sure you've installed them and try reinstalling them if this issue persists.");
-        starterr_message_table[Define.RecordError.CONFIGURE_ERROR] = N_("This is possibly due to missing sound input or output devices. Make sure you've connected one and try using another one if this issue persists.");
+        starterr_message_table[Define.RecordError.CREATE_ERROR] = N_("This is possibly due to missing codecs or incomplete installation of the app. Make sure you've installed them and try reinstalling them if this issue persists");
+        starterr_message_table[Define.RecordError.CONFIGURE_ERROR] = N_("This is possibly due to missing sound input or output devices. Make sure you've connected one and try using another one if this issue persists");
     }
 
     construct {
@@ -125,8 +125,8 @@ public class MainWindow : Adw.ApplicationWindow {
 
         record_manager.throw_error.connect ((err, debug) => {
             show_error_dialog (
-                _("Error while recording"),
-                _("There was an error while recording."),
+                _("Failed to Complete Recording"),
+                _("There was an error while recording"),
                 "%s\n%s".printf (err.message, debug)
             );
         });
@@ -183,8 +183,8 @@ public class MainWindow : Adw.ApplicationWindow {
                 }
 
                 show_error_dialog (
-                    _("Failed to save recording"),
-                    _("There was an error while asking for final path where to move the temporary recording file \"%s\"."
+                    _("Failed to Save Recording"),
+                    _("There was an error while asking for final path where to move the temporary recording file \"%s\""
                         .printf (tmp_path)
                     ),
                     err.message
@@ -203,8 +203,8 @@ public class MainWindow : Adw.ApplicationWindow {
             tmp_file.move (final_file, FileCopyFlags.OVERWRITE);
         } catch (Error err) {
             show_error_dialog (
-                _("Failed to save recording"),
-                _("There was an error while moving the temporary recording file \"%s\" to \"%s\"."
+                _("Failed to Save Recording"),
+                _("There was an error while moving the temporary recording file \"%s\" to \"%s\""
                     .printf (tmp_file.get_path (), final_path)
                 ),
                 err.message
@@ -227,7 +227,7 @@ public class MainWindow : Adw.ApplicationWindow {
      */
     private async File? ask_final_file (string default_filename) throws Error {
         var save_dialog = new Gtk.FileDialog () {
-            title = _("Save your recording"),
+            title = _("Save Recording"),
             modal = true,
             initial_name = default_filename
         };
@@ -277,11 +277,11 @@ public class MainWindow : Adw.ApplicationWindow {
             string? secondary_text = starterr_message_table[err.code];
             // Errors without dedicated message
             if (secondary_text == null) {
-                secondary_text = N_("There was an unknown error while starting recording.");
+                secondary_text = N_("There was an unknown error while starting recording");
             }
 
             show_error_dialog (
-                _("Failed to start recording"),
+                _("Failed to Start Recording"),
                 _(secondary_text),
                 err.message
             );

--- a/src/Manager/DeviceManager.vala
+++ b/src/Manager/DeviceManager.vala
@@ -60,7 +60,7 @@ public class Manager.DeviceManager : Object {
     private void update_devices () {
         bool is_default;
 
-        debug ("update_devices start.");
+        debug ("update_devices start");
 
         sources.clear ();
         sinks.clear ();
@@ -123,6 +123,6 @@ public class Manager.DeviceManager : Object {
 
         device_updated ();
 
-        debug ("update_devices end.");
+        debug ("update_devices end");
     }
 }

--- a/src/View/CountDownView.vala
+++ b/src/View/CountDownView.vala
@@ -34,7 +34,7 @@ public class View.CountDownView : AbstractView {
 
         var cancel_button = new Gtk.Button () {
             icon_name = "user-trash-symbolic",
-            tooltip_text = _("Cancel the countdown"),
+            tooltip_text = _("Cancel Countdown"),
             halign = Gtk.Align.START
         };
         cancel_button.add_css_class ("borderless-button");
@@ -118,11 +118,11 @@ public class View.CountDownView : AbstractView {
 
     private void pause_button_set_pause () {
         pause_button.icon_name = "media-playback-pause-symbolic";
-        pause_button.tooltip_text = _("Pause the countdown");
+        pause_button.tooltip_text = _("Pause Countdown");
     }
 
     private void pause_button_set_resume () {
         pause_button.icon_name = "media-playback-start-symbolic";
-        pause_button.tooltip_text = _("Resume the countdown");
+        pause_button.tooltip_text = _("Resume Countdown");
     }
 }

--- a/src/View/RecordView.vala
+++ b/src/View/RecordView.vala
@@ -48,14 +48,14 @@ public class View.RecordView : AbstractView {
 
         var cancel_button = new Gtk.Button () {
             icon_name = "user-trash-symbolic",
-            tooltip_text = _("Cancel recording"),
+            tooltip_text = _("Cancel Recording"),
             halign = Gtk.Align.START
         };
         cancel_button.add_css_class ("borderless-button");
 
         var stop_button = new Gtk.Button () {
             icon_name = "media-playback-stop-symbolic",
-            tooltip_text = _("Finish recording"),
+            tooltip_text = _("Finish Recording"),
             halign = Gtk.Align.CENTER,
             width_request = 48,
             height_request = 48
@@ -185,7 +185,7 @@ public class View.RecordView : AbstractView {
         downtimer.stop ();
 
         pause_button.icon_name = "media-playback-start-symbolic";
-        pause_button.tooltip_text = _("Resume recording");
+        pause_button.tooltip_text = _("Resume Recording");
 
         levelbar.refresh_pause ();
     }
@@ -197,7 +197,7 @@ public class View.RecordView : AbstractView {
         }
 
         pause_button.icon_name = "media-playback-pause-symbolic";
-        pause_button.tooltip_text = _("Pause recording");
+        pause_button.tooltip_text = _("Pause Recording");
 
         levelbar.refresh_resume ();
     }

--- a/src/View/WelcomeView.vala
+++ b/src/View/WelcomeView.vala
@@ -6,6 +6,10 @@
 public class View.WelcomeView : AbstractView {
     public signal void start_recording (uint delay_sec);
 
+    ///TRANSLATORS: This is the label of a button that shows a file dialog to select a folder
+    // where the app saves recodings automatically
+    private const string DESTINATION_CHOOSER_DEFAULT_LABEL = N_("Destination…");
+
     private unowned Manager.DeviceManager device_manager;
 
     private Ryokucha.DropDownText source_combobox;
@@ -105,7 +109,7 @@ public class View.WelcomeView : AbstractView {
             halign = Gtk.Align.START,
         };
 
-        var metadata_desc_label = new Gtk.Label (_("Add record year and your real name in recording files.")) {
+        var metadata_desc_label = new Gtk.Label (_("Add record year and your real name in recording files")) {
             halign = Gtk.Align.START,
             wrap = true,
             width_chars = 28,
@@ -122,11 +126,11 @@ public class View.WelcomeView : AbstractView {
         };
 
         destination_chooser_button = new Widget.FolderChooserButton (
-            _("Select destination…"),
-            _("Choose a default destination")
+            _(DESTINATION_CHOOSER_DEFAULT_LABEL),
+            _("Select AutoSave Destination")
         ) {
             halign = Gtk.Align.START,
-            tooltip_text = _("Choose a default destination")
+            tooltip_text = _("Select AutoSave Destination")
         };
 
         string autosave_path = Application.settings.get_string ("autosave-destination");
@@ -164,7 +168,7 @@ public class View.WelcomeView : AbstractView {
 
         record_button = new Gtk.Button () {
             icon_name = "audio-input-microphone-symbolic",
-            tooltip_text = _("Start recording"),
+            tooltip_text = _("Start Recording"),
             halign = Gtk.Align.CENTER,
             margin_top = 12,
             width_request = 48,
@@ -254,7 +258,7 @@ public class View.WelcomeView : AbstractView {
         } else {
             // Clear the current destination and disable autosaving
             Application.settings.reset ("autosave-destination");
-            destination_chooser_button.label = _("Select destination…");
+            destination_chooser_button.label = _(DESTINATION_CHOOSER_DEFAULT_LABEL);
         }
     }
 

--- a/src/Widget/ProcessingDialog.vala
+++ b/src/Widget/ProcessingDialog.vala
@@ -37,13 +37,13 @@ public class Widget.ProcessingDialog : Adw.Dialog {
         };
         desc_label.add_css_class ("title-3");
 
-        var cancel_label = new Gtk.Label (_("Problems?") + "\n" + _("Just hang on until the file dialog appears.")) {
+        var cancel_label = new Gtk.Label (_("Problems?") + "\n" + _("Just hang on until the file dialog appears")) {
             halign = Gtk.Align.CENTER,
         };
 
         var cancel_button = new Gtk.Button () {
             icon_name = "user-trash-symbolic",
-            tooltip_text = _("Cancel recording"),
+            tooltip_text = _("Cancel Recording"),
             halign = Gtk.Align.CENTER,
         };
         cancel_button.add_css_class ("borderless-button");


### PR DESCRIPTION
- Use Header Capitalization for titles and tooltip texts
- No trailing period
- Unify recording error headings to the form `Failed to <Verb> Recording`
- Drop `your` and `the` in Header Capitalization
- FolderChooserButton
  - Explicit autosave
  - Use the GTK's default notation `Select` instead of `Choose`

See also: https://developer.gnome.org/hig/guidelines/writing-style.html
