### PR TITLE
fix: MainWindow: Make sure to destroy error dialog on any response

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -398,10 +398,8 @@ public class MainWindow : Adw.ApplicationWindow {
                 modal = true
             };
             error_dialog.show_error_details (error_message);
-            error_dialog.response.connect ((response_id) => {
-                if (response_id == Gtk.ResponseType.CLOSE) {
-                    error_dialog.destroy ();
-                }
+            error_dialog.response.connect (() => {
+                error_dialog.destroy ();
             });
             error_dialog.present ();
 #endif


### PR DESCRIPTION
Fixes a potential bug that the error dialog does not close if it receives responses other than `Gtk.ResponseType.CLOSE`
