### PR TITLE
feat: desktop: Set StartupNotify to true

### DIFF
--- a/data/reco.desktop.in.in
+++ b/data/reco.desktop.in.in
@@ -8,3 +8,4 @@ Icon=@APP_ID@
 Terminal=false
 Type=Application
 Keywords=Record;Audio;Sound;Voice;
+StartupNotify=true


### PR DESCRIPTION
This allows showing startup loading screen in some DEs like Phosh
