### PR TITLE
refactor: MainWindow: Generalize show_error_dialog()

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -133,11 +133,15 @@ public class MainWindow : Adw.ApplicationWindow {
         });
 
         record_manager.record_err.connect ((err, debug_info) => {
+            record_view.refresh_end ();
+
             show_error_dialog (
                 _("Unable to Continue Recording"),
                 _("There was an internal error while recording"),
                 "%s\n%s".printf (err.message, debug_info)
             );
+
+            show_welcome ();
         });
 
         record_manager.record_ok.connect (save_file_wrapper);
@@ -471,6 +475,16 @@ public class MainWindow : Adw.ApplicationWindow {
         });
     }
 
+    /**
+     * Present an error dialog
+     *
+     * This uses {@link Granite.MessageDialog} on Pantheon if the app build with Granite,
+     * otherwise it uses {@link Adw.AlertDialog}
+     *
+     * @param primary_text      the title of the dialog
+     * @param secondary_text    the body of the dialog
+     * @param detailed_text     the detailed error message to display if any
+     */
     private void show_error_dialog (string primary_text, string secondary_text, string? detailed_text = null) {
         if (Util.is_on_pantheon ()) {
 #if USE_GRANITE
@@ -508,8 +522,5 @@ public class MainWindow : Adw.ApplicationWindow {
             });
             error_dialog.present (this);
         }
-
-        record_view.refresh_end ();
-        show_welcome ();
     }
 }


### PR DESCRIPTION
This is only the occurrence that needs `refresh_end()` and `show_welcome()`.

```vala
        record_manager.record_err.connect ((err, debug_info) => {
            show_error_dialog (
                _("Unable to Continue Recording"),
                _("There was an internal error while recording"),
                "%s\n%s".printf (err.message, debug_info)
            );
        });
```

Not needed because RecordView calls `refresh_end()` by itself before emitting `stop_recording()` signal and MainWindow calls `show_welcome()` at the end of `save_file_wrapper()` which calls `save_file()`.

```vala
    private async string? save_file (string tmp_path, string default_filename) {
        :

        try {
            tmp_file.move (final_file, FileCopyFlags.OVERWRITE);
        } catch (Error err) {
            warning ("Failed to File.move: src=\"%s\" dst=\"%s\": %s", tmp_path, final_path, err.message);

            show_error_dialog (
                _("Failed to Save Recording"),
                _("Unable to move a temporary recording file to the final path. Make sure the destination exists and you have write access to it"),
                err.message
            );

            return null;
        }
```

Same as above; `save_file()` calls `ask_final_file()`.

```vala
    private async File? ask_final_file (string default_filename) {
        :

        File? final_file;
        try {
            final_file = yield save_dialog.save (this, null);
        } catch (Error err) {
            if (err.domain == Gtk.DialogError.quark () && err.code == Gtk.DialogError.DISMISSED) {
                yield cleanup_tmp_recording ();

                // Don't show the warning log when the dialog is just dismissed by the user
                return null;
            }

            warning ("Failed to Gtk.FileDialog.save: %s", err.message);

            show_error_dialog (
                _("Failed to Save Recording"),
                _("Unable to determine where to save recording finally. Try again using autosave instead"),
                err.message
            );

            return null;
        }
```

Not needed because we're in the welcome view and before calling `refresh_begin()`.

```vala
    private void show_record () {
        :

        bool ret = record_manager.prepare (recording_tmp_path, source, channel, format, meta_author, meta_record_dt);
        if (!ret) {
            show_error_dialog (
                _("Failed to Prepare Recording"),
                _("This is possibly due to missing codecs, incomplete installation of the app, or missing sound input/output devices. Make sure you've installed necessary components correctlly and connected sound devices")
            );

            return;
        }

        inhibit_sleep ();

        record_manager.start ();

        record_view.refresh_begin ();
        stack.visible_child = record_view;
    }
```

Rather we shouldn't call `refresh_end()` and `show_welcome()` here because this is an action handler for a toast which can alive in any views if it's hovered, which means the view changes unexpectedly if this action is triggered while next recording.

```vala
    private void on_open_folder_activate (SimpleAction action, Variant? parameter) requires (parameter != null) {
        unowned string path = parameter.get_string ();
        var launcher = new Gtk.FileLauncher (File.new_for_path (path));

        launcher.open_containing_folder.begin (this, null, (obj, res) => {
            try {
                launcher.open_containing_folder.end (res);
            } catch (Error err) {
                warning ("Failed to Gtk.FileLauncher.open_containing_folder: %s", err.message);

                show_error_dialog (
                    _("Failed to Open Folder"),
                    _("Unable to open folder containing \"%s\"").printf (path),
                    err.message
                );
            }
        });
    }
```
