### PR TITLE
chore: Remove no longer needed version limitation for ryokucha

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You'll need the following dependencies to build:
 * libgranite-7-dev (>= 7.2.0, required only when you build with `granite` feature enabled)
 * libgstreamer1.0-dev (>= 1.20)
 * libgtk-4-dev (>= 4.12)
-* [libryokucha](https://github.com/ryonakano/ryokucha) (>= 0.4.0)
+* [libryokucha](https://github.com/ryonakano/ryokucha)
 * [livechart](https://github.com/lcallarec/live-chart) (>= 1.10.0)
     * alternatively, [livechart-2 (the elementary fork)](https://github.com/elementary/live-chart) (>= 2.0.0)
 * meson (>= 0.58.0)

--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,7 @@ dependencies = [
   dependency('libadwaita-1', version: '>= 1.6.0'),
   livechart_dep,
   dependency('pango'),
-  dependency('ryokucha', version: '>= 0.4.0', allow_fallback: get_option('use_submodule')),
+  dependency('ryokucha', allow_fallback: get_option('use_submodule')),
 ]
 
 subdir('data')


### PR DESCRIPTION
This was because we want to inherit default value of `Ryokucha.DropDownText.max_width_chars` for `mic_combobox` that was missing in ryokucha < 0.4.0, but `mic_combobox` is now replaced with the pure Gtk.DropDown in #438, so this version limitation is no longer necessary.
