### PR TITLE
Document add metadata feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Features include:
 * **Recording sounds from both your microphone and system at the same time.** This is useful for recording calls or streaming videos on the Internet.
 * **Saving in many commonly used formats.** It supports ALAC, FLAC, MP3, Ogg Vorbis, Opus, and WAV.
 * **Timed recording.** You can set a delay before recording up to 15 seconds, and set the length of recording up to 600 seconds.
+* **Adding metadata automatically.** Reco can add artist and year metadata to recording files.
 * **Choosing where to save recordings.** You can select whether the app saves recordings into a directory of your choosing automatically or manually.
 * **Saving recordings when the app quits.** Even if you happen to quit the app while recording, the recording is either saved automatically, or the file chooser dialog is shown - depending on your preferences.
 

--- a/data/reco.metainfo.xml.in.in
+++ b/data/reco.metainfo.xml.in.in
@@ -19,6 +19,7 @@
       <li>Recording sounds from both your microphone and system at the same time. This is useful for recording calls or streaming videos on the Internet.</li>
       <li>Saving in many commonly used formats. It supports ALAC, FLAC, MP3, Ogg Vorbis, Opus, and WAV.</li>
       <li>Timed recording. You can set a delay before recording up to 15 seconds, and set the length of recording up to 600 seconds.</li>
+      <li>Adding metadata automatically. Reco can add artist and year metadata to recording files.</li>
       <li>Choosing where to save recordings. You can select whether the app saves recordings into a directory of your choosing automatically or manually.</li>
       <li>Saving recordings when the app quits. Even if you happen to quit the app while recording, the recording is either saved automatically, or the file chooser dialog is shown - depending on your preferences.</li>
     </ul>


### PR DESCRIPTION
## Summary

Documents Reco's automatic metadata feature in both the README feature list and AppStream metainfo description.

Closes #451.

## Testing

- `git diff --check`
- `xmllint --noout data/reco.metainfo.xml.in.in`