### PR TITLE
Revert "metainfo: Use revision instead of version for screenshots URL"

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -39,7 +39,7 @@ appstream_conf.set('APP_ID', app_id)
 appstream_conf.set('GETTEXT_PACKAGE', meson.project_name())
 # Use screenshots taken on Pantheon, which is a publishing requirement for AppCenter, if build with granite.
 appstream_conf.set('DE', get_option('granite').enabled() ? 'pantheon' : 'gnome')
-appstream_conf.set('APP_REVISION', app_revision)
+appstream_conf.set('VERSION', meson.project_version())
 appstream_file_in = configure_file(
   input: 'reco.metainfo.xml.in.in',
   output: '@0@.metainfo.xml.in'.format(app_id),

--- a/data/reco.metainfo.xml.in.in
+++ b/data/reco.metainfo.xml.in.in
@@ -28,12 +28,12 @@
   <screenshots>
     <screenshot type="default">
       <caption>Welcome view; perform recording configuration</caption>
-      <image>https://raw.githubusercontent.com/ryonakano/reco/@APP_REVISION@/data/screenshots/@DE@/welcome-light.png</image>
+      <image>https://raw.githubusercontent.com/ryonakano/reco/@VERSION@/data/screenshots/@DE@/welcome-light.png</image>
     </screenshot>
 
     <screenshot>
       <caption>Recording view</caption>
-      <image>https://raw.githubusercontent.com/ryonakano/reco/@APP_REVISION@/data/screenshots/@DE@/recording-light.png</image>
+      <image>https://raw.githubusercontent.com/ryonakano/reco/@VERSION@/data/screenshots/@DE@/recording-light.png</image>
     </screenshot>
   </screenshots>
 

--- a/meson.build
+++ b/meson.build
@@ -22,12 +22,6 @@ if get_option('development')
   app_version += version_suffix
 endif
 
-app_revision = 'main'
-ret = run_command('git', 'rev-parse', 'HEAD', check: false)
-if ret.returncode() == 0
-  app_revision = ret.stdout().strip()
-endif
-
 gnome = import('gnome')
 i18n = import('i18n')
 


### PR DESCRIPTION
Reverts ryonakano/reco#368

We won't need this because now that we publish interim releases.
